### PR TITLE
create cacheDirectory automatically

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+var mkdirp = require('mkdirp');
 
 var mtime = require('./mtime');
 var digest = require('./digest');
@@ -15,7 +16,14 @@ function OnlyIfChangedPlugin(opts) {
   this.cacheIdentifier = digest.digestSHA1(JSON.stringify(opts.cacheIdentifier));
   this.concurrencyLimit = opts.concurrencyLimit || CONCURRENCY_LIMIT;
   this.cache = makeCacheRecord();
+  this.makeCacheDirectory();
 }
+
+OnlyIfChangedPlugin.prototype.makeCacheDirectory = function() {
+  mkdirp(this.cacheDirectory, function(err) {
+    if (err) console.error(err);
+  });
+};
 
 OnlyIfChangedPlugin.prototype.getCacheFilePath = function() {
   return path.join(this.cacheDirectory, 'onlyifchanged-' + SCHEMA_VERSION + '-' + this.cacheIdentifier + '.json');

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "async": "^1.5.2"
+    "async": "^1.5.2",
+    "mkdirp": "^0.5.1"
   },
   "devDependencies": {
     "eslint": "^2.7.0",


### PR DESCRIPTION
Running the `only-if-changed-webpack-plugin` without manually creating the `cacheDirectory` causes the plugin to fail. Automatically creating a directory when the plugin is run will ensure the cache always has a real directory to write to.