### PR TITLE
Fix for Epoch timestamps

### DIFF
--- a/mtime.js
+++ b/mtime.js
@@ -32,7 +32,7 @@ function getFilesChanges(filesMtimes, concurrencyLimit, done) {
       }
 
       var mtimeNew = stat.mtime.getTime();
-      if (!(filesMtimes[file] && mtimeNew && mtimeNew <= filesMtimes[file])) {
+      if (mtimeNew > Number(filesMtimes[file])) {
         changed.push(file);
       }
       fileDone();

--- a/support/testUtils.js
+++ b/support/testUtils.js
@@ -54,8 +54,12 @@ function readFile(filepath) {
   return contents;
 }
 
-function writeFile(filepath, content) {
+function writeFile(filepath, content, unixtime) {
   fs.writeFileSync(filepath, content, {encoding: 'utf8'});
+
+  if (typeof unixtime !== 'undefined') {
+    fs.utimesSync(filepath, unixtime, unixtime);
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
`npm publish` [briefly published packages with all files set to the Unix epoch](https://github.com/npm/npm/issues/19968#issuecomment-372799983).
This plugin was incorrectly seeing such files as modified, because the timestamp was falsy.