### PR TITLE
Workaround for fileDependencies of SortableSet-type

### DIFF
--- a/mtime.js
+++ b/mtime.js
@@ -7,7 +7,7 @@ function getFilesMtimes(files, concurrencyLimit, done) {
     if (typeof file !== 'string') {
       return fileDone();
     }
-    
+
     fs.stat(file, function(statErr, stat) {
       if (statErr) {
         if (statErr.code === 'ENOENT') return fileDone();

--- a/mtime.js
+++ b/mtime.js
@@ -4,6 +4,10 @@ var async = require('async');
 function getFilesMtimes(files, concurrencyLimit, done) {
   var filesMtimes = {};
   async.eachLimit(files, concurrencyLimit, function(file, fileDone) {
+    if (typeof file !== 'string') {
+      return fileDone();
+    }
+    
     fs.stat(file, function(statErr, stat) {
       if (statErr) {
         if (statErr.code === 'ENOENT') return fileDone();


### PR DESCRIPTION
When webpack fileDependencies is of a `SortableSet`-type the `getFilesMtimes`-function returns a `TypeError: path must be a string or Buffer`-error.

With this commit the function `getFilesMtimes` checks if the `file`-variable is a string before continuing the file-check.