### PR TITLE
Ensure compilation.fileDependencies is always an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,8 +129,11 @@ OnlyIfChangedPlugin.prototype.apply = function(compiler) {
 
   // collect info about input dependencies to compilation
   compiler.plugin('after-compile', function(compilation, afterCompileDone) {
+    // convert to array in case webpack gives us a set (in webpack v4)
+    var fileDependencies = Array.from(compilation.fileDependencies);
+
     // get updated mtimes of file dependencies of compilation
-    pluginContext.updateDependenciesMtimes(compilation.fileDependencies, afterCompileDone);
+    pluginContext.updateDependenciesMtimes(fileDependencies, afterCompileDone);
   });
 
   compiler.plugin('should-emit', function() {


### PR DESCRIPTION
Addresses #9. Without this PR, the `only-if-changed-webpack-plugin` does not work with Webpack v4.

With this PR, it works with Webpack v4 (tested with Webpack v4.0.0 and 4.42.2)